### PR TITLE
Aligning the package versions

### DIFF
--- a/infrastructure/cdk/package.json
+++ b/infrastructure/cdk/package.json
@@ -13,11 +13,11 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "^1.63.0",
-    "@types/jest": "^26.0.14",
+    "@aws-cdk/assert": "^1.83.0",
+    "@types/jest": "^26.0.20",
     "aws-cdk": "^1.83.0",
-    "jest": "^26.4.2",
-    "ts-node": "^9.0.0",
+    "jest": "^26.6.3",
+    "ts-node": "^9.1.1",
     "typescript": "^3.9.7"
   },
   "jest": {
@@ -26,7 +26,6 @@
     ]
   },
   "dependencies": {
-    "source-map-support": "^0.5.9",
     "@aws-cdk/aws-apigateway": "^1.83.0",
     "@aws-cdk/aws-cloudformation": "^1.83.0",
     "@aws-cdk/aws-cloudfront": "^1.83.0",
@@ -42,8 +41,9 @@
     "@aws-cdk/aws-sqs": "^1.83.0",
     "@aws-cdk/aws-ssm": "^1.83.0",
     "@aws-cdk/core": "^1.83.0",
-    "@types/node": "^12.7.3",
-    "aws-sdk": "^2.521.0",
-    "uuid": "^8.3.2"
+    "@types/node": "^12.19.12",
+    "aws-sdk": "^2.824.0",
+    "source-map-support": "^0.5.19",
+    "uuid": "^3.4.0"
   }
 }


### PR DESCRIPTION
*Description of changes:*
By running *npmvet* I identified misalignment with the package versions. Did an alignment, run a build to test the full deployment, and everything is ok. Some deprecations are still there but they are related to JEST.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
