### PR TITLE
Fix Dependabot security vulnerabilities

### DIFF
--- a/infrastructure/cdk/package-lock.json
+++ b/infrastructure/cdk/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/client-cognito-identity-provider": "^3.986.0",
         "@aws-sdk/client-s3": "^3.986.0",
         "@types/node": "^20.5.1",
-        "aws-cdk-lib": "^2.240.0",
+        "aws-cdk-lib": "^2.257.0",
         "constructs": "^10.0.0",
         "uuid": "^14.0.0"
       },
@@ -22,7 +22,7 @@
       },
       "devDependencies": {
         "@types/jest": "^24.0.18",
-        "aws-cdk-lib": "^2.240.0",
+        "aws-cdk-lib": "^2.257.0",
         "constructs": "^10.0.0",
         "jest": "^29.1.2",
         "ts-node": "^9.1.1",
@@ -33,7 +33,7 @@
         "npm": ">=9.0.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.240.0",
+        "aws-cdk-lib": "^2.257.0",
         "constructs": "^10.0.0"
       }
     },
@@ -51,21 +51,23 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.263",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.263.tgz",
-      "integrity": "sha512-X9JvcJhYcb7PHs8R7m4zMablO5C9PGb/hYfLnxds9h/rKJu6l7MiXE/SabCibuehxPnuO/vk+sVVJiUWrccarQ==",
-      "dev": true
+      "version": "2.2.273",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz",
+      "integrity": "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
-      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==",
-      "dev": true
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
+      "integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "50.4.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-50.4.0.tgz",
-      "integrity": "sha512-9Cplwc5C+SNe3hMfqZET7gXeM68tiH2ytQytCi+zz31Bn7O3GAgAnC2dYe+HWnZAgVH788ZkkBwnYXkeqx7v4g==",
+      "version": "53.28.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.28.0.tgz",
+      "integrity": "sha512-pZS+9bLGv2tCqcgxfA0WD3XjcqT3yE4ICvKeJEicw6aTdCxBl8FQ/AUsorY/6f2JrMS3kUQgvhXxA30MWcji0A==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -73,15 +75,15 @@
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.3"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -90,7 +92,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.3",
+      "version": "7.8.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -1072,13 +1074,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.17.tgz",
-      "integrity": "sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==",
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.26.tgz",
+      "integrity": "sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "fast-xml-parser": "5.5.8",
+        "@smithy/types": "^4.14.2",
+        "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1934,6 +1936,18 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.25.24",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
@@ -2413,9 +2427,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.0.tgz",
-      "integrity": "sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2826,9 +2840,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.240.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.240.0.tgz",
-      "integrity": "sha512-3dXmUnPB5kK0VgrNHOlV3jiQM4Dungukk/CV91nclO2lgNcrGyigauJdzmz9sOmI1gbKJJ2SRAotaXityzZMRw==",
+      "version": "2.257.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz",
+      "integrity": "sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -2846,60 +2860,47 @@
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.263",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-api": "^2.0.1",
-        "@aws-cdk/cloud-assembly-schema": "^50.3.0",
+        "@aws-cdk/asset-awscli-v1": "2.2.273",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
+        "@aws-cdk/cloud-assembly-api": "^2.2.4",
+        "@aws-cdk/cloud-assembly-schema": "^53.25.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.3",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
-        "minimatch": "^10.2.1",
+        "minimatch": "^10.2.3",
         "punycode": "^2.3.1",
         "semver": "^7.7.4",
         "table": "^6.9.0",
-        "yaml": "1.10.2"
+        "yaml": "1.10.3"
       },
       "engines": {
-        "node": ">= 18.0.0"
+        "node": ">= 20.0.0"
       },
       "peerDependencies": {
         "constructs": "^10.5.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.0.1",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
+      "version": "2.2.4",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.3"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=50.3.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
+        "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.7.3",
+      "version": "7.8.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -2975,7 +2976,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.3",
+      "version": "5.0.5",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3026,7 +3027,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
       "dev": true,
       "funding": [
         {
@@ -3134,12 +3135,12 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
-      "version": "10.2.2",
+      "version": "10.2.5",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -3247,7 +3248,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
-      "version": "1.10.2",
+      "version": "1.10.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3358,9 +3359,9 @@
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3774,9 +3775,9 @@
       "dev": true
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -3785,13 +3786,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "funding": [
         {
           "type": "github",
@@ -3800,9 +3802,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -5250,9 +5253,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.4.0.tgz",
-      "integrity": "sha512-s4DQMxIdhj3jLFWd9LxHOplj4p9yQ4ffMGowFf3cpEgrrJjEhN0V5nxw4Ye1EViAGDoL4/1AeO6qHpqYPOzE4Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -5604,9 +5607,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -5868,6 +5871,21 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/y18n": {

--- a/infrastructure/cdk/package.json
+++ b/infrastructure/cdk/package.json
@@ -14,14 +14,14 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.18",
-    "aws-cdk-lib": "^2.240.0",
+    "aws-cdk-lib": "^2.257.0",
     "constructs": "^10.0.0",
     "jest": "^29.1.2",
     "ts-node": "^9.1.1",
     "typescript": "^5.1.6"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.240.0",
+    "aws-cdk-lib": "^2.257.0",
     "constructs": "^10.0.0"
   },
   "jest": {
@@ -34,9 +34,9 @@
     "@aws-sdk/client-cognito-identity-provider": "^3.986.0",
     "@aws-sdk/client-s3": "^3.986.0",
     "@types/node": "^20.5.1",
-    "aws-cdk-lib": "^2.240.0",
     "constructs": "^10.0.0",
-    "uuid": "^14.0.0"
+    "uuid": "^14.0.0",
+    "aws-cdk-lib": "^2.257.0"
   },
   "engines": {
     "node": ">=20.5.1",


### PR DESCRIPTION
## Summary
Bumps aws-cdk-lib from 2.240.0 to 2.257.0 and updates transitive dependencies to resolve security vulnerabilities.

## Vulnerabilities Fixed
- #63 fast-xml-builder: attribute bypass (High)
- #57 fast-uri: path traversal (High)
- #58 fast-uri: host confusion (High)
- #44 minimatch: ReDoS (High)
- #55 fast-xml-parser: XML/CDATA injection (Moderate)
- brace-expansion: zero-step DoS (Moderate)
- yaml: stack overflow (Moderate)

## Remaining
One moderate vulnerability (brace-expansion 5.0.5 — GHSA-jxxr-4gwj-5jf2) bundled inside aws-cdk-lib@2.257.0 (latest). Will resolve when CDK team releases a fix.

## Testing
- TypeScript compilation: ✅
- All 6 tests pass: ✅
